### PR TITLE
Check the server for Setup-SD.png

### DIFF
--- a/HMS/source/checkServerUrl.brs
+++ b/HMS/source/checkServerUrl.brs
@@ -13,7 +13,7 @@ Function checkServerUrl(forceEdit As Boolean) As Boolean
     if (serverUrl = invalid) then
         print "ServerUrl not found in the registry"
         serverUrl = "video.local"
-    else if not forceEdit and isUrlValid(serverUrl) then
+    else if not forceEdit and isUrlValid(serverUrl+"/Setup-SD.png") then
         print "Server set to "; serverUrl
         return true
     end if

--- a/README
+++ b/README
@@ -62,6 +62,10 @@ by Brian C. Lane <bcl@brianlane.com>
 
   Search-HD.png  Search-SD.png  Setup-HD.png  Setup-SD.png
 
+  IMPORTANT: As of v3.1 /Setup-SD.png is required for HMS to start. If it is
+  missing it will fall into the URL editing dialog.  This is so that you can
+  more easily recover from entering an incorrect URL.
+
   Sample directory listing:
     Firefly/
     Home_Movies/


### PR DESCRIPTION
There are some situations where HMS could get stuck and not allow you to
edit the URL of the server. eg. enter an IP address of a http server
without a directory listing.

This commits requires that the server have /Setup-SD.png available. If
it isn't it will fall into the URL editing dialog.